### PR TITLE
fix/36-rails-admin-assets

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,3 +10,5 @@ Rails.application.config.assets.version = "1.0"
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w[ admin.js admin.css ]
+
+Rails.application.config.assets.css_compressor = nil # CSSを圧縮しないようにする(Tailwindとsassc-rails互換性の問題解消のため)


### PR DESCRIPTION
## 概要
- CSS圧縮を無効化の記述を追加 (Tailwindとsassc-rails互換性問題のため)

## 背景
本番環境の管理画面エラーの修正 #36

## 変更内容
- `config/environments/production.rb`に`Rails.application.config.assets.css_compressor = nil`を追加しました

## 確認方法
1. `rails assets:precompile` を実行してエラーが出ないことを確認
2. 本番相当環境で管理画面にアクセスできること

## 補足
- 今回の修正でエラーを解消できなかった場合は、別PRで対応予定