### PR TITLE
fix/40-seed-foods

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,67 +12,78 @@ foods = [
     name: "ハラミ",
     rarity: "common",
     image_url: "foods/harami.jpg",
-    description: "横隔膜の腹側で、柔らかく適度に脂肪がある。"
+    description: "横隔膜の腹側で、柔らかく適度に脂肪がある。",
+    category_id: 1
   },
   {
     name: "サガリ",
     rarity: "common",
     image_url: "foods/sagari.jpg",
-    description: "横隔膜の腰椎に近い部分で脂身がなく、あっさりしていてスジが少なく柔らかい。"
+    description: "横隔膜の腰椎に近い部分で脂身がなく、あっさりしていてスジが少なく柔らかい。",
+    category_id: 1
   },
   {
     name: "ランプ",
     rarity: "common",
     image_url: "foods/rump.jpg",
-    description: "もも肉の中でも柔らかく、味に深みがある。"
+    description: "もも肉の中でも柔らかく、味に深みがある。",
+    category_id: 1
   },
   {
     name: "イチボ",
     rarity: "common",
     image_url: "foods/ichibo.jpg",
-    description: "臀部の骨周りに位置する部位で、赤身と脂のバランスが良い。"
+    description: "臀部の骨周りに位置する部位で、赤身と脂のバランスが良い。",
+    category_id: 1
   },
   {
     name: "フランク（ササミ）",
     rarity: "rare",
     image_url: "foods/frank.jpg",
-    description: "肉質はきめが細かく柔らかい。"
+    description: "肉質はきめが細かく柔らかい。",
+    category_id: 1
   },
   {
     name: "ミスジ",
     rarity: "rare",
     image_url: "foods/misuji.jpg",
-    description: "霜降りが美しく柔らかい。"
+    description: "霜降りが美しく柔らかい。",
+    category_id: 1
   },
   {
     name: "トモサンカク",
     rarity: "rare",
     image_url: "foods/tomo-sankaku.jpg",
-    description: "霜降りがしっかり入り、赤身の旨味も楽しめる。"
+    description: "霜降りがしっかり入り、赤身の旨味も楽しめる。",
+    category_id: 1
   },
   {
     name: "カイノミ",
     rarity: "rare",
     image_url: "foods/kainomi.jpg",
-    description: "ヒレのような柔らかさと脂の旨みがある。"
+    description: "ヒレのような柔らかさと脂の旨みがある。",
+    category_id: 1
   },
   {
     name: "ザブトン（ハネシタ）",
     rarity: "rare",
     image_url: "foods/zabuton.jpg",
-    description: "全体に美しいサシが入り、濃厚でとろける味わい。"
+    description: "全体に美しいサシが入り、濃厚でとろける味わい。",
+    category_id: 1
   },
   {
     name: "シンシン（マルシン）",
     rarity: "epic",
     image_url: "foods/shinshin.jpg",
-    description: "きめ細かく濃厚で柔らかな赤身。"
+    description: "きめ細かく濃厚で柔らかな赤身。",
+    category_id: 1
   },
   {
     name: "トンビ（トウガラシ）",
     rarity: "epic",
     image_url: "foods/tonbi.jpg",
-    description: "旨味が強く、形が唐辛子に似ている。"
+    description: "旨味が強く、形が唐辛子に似ている。",
+    category_id: 1
   }
 ]
 
@@ -81,5 +92,6 @@ foods.each do |data|
     record.rarity = data[:rarity]
     record.image_url = data[:image_url]
     record.description = data[:description]
+    record.category_id = data[:category_id]
   end
 end


### PR DESCRIPTION
## 概要
- `seeds.rb`の修正

## 背景
食材初期データの修正 #40

## 変更内容
-  `seeds.rb`の食材データに`category_id`を追加しました

## 確認方法
- `rails db:seed`で食材初期データが作成されること

## 補足
`seeds.rb`のデータを`admin_rails`のエクスポートで作成したため、`category_id`が抜けていることを失念しておりました。