### PR TITLE
feature/16-wishlist-food

### DIFF
--- a/app/controllers/wishlist_foods_controller.rb
+++ b/app/controllers/wishlist_foods_controller.rb
@@ -1,0 +1,11 @@
+class WishlistFoodsController < ApplicationController
+  def create
+    @food = Food.find(params[:food_id])
+    current_user.wishlist(@food)
+  end
+
+  def destroy
+    @food = current_user.wishlist_foods.find(params[:id]).food
+    current_user.unwishlist(@food)
+  end
+end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,6 +1,7 @@
 class Food < ApplicationRecord
-  belongs_to :category
-
   validates :name, presence: true
   enum rarity: { common: 1, rare: 2, epic: 3 }
+
+  belongs_to :category
+  has_many :wishlist_foods, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,14 +10,14 @@ class User < ApplicationRecord
   has_many :wishlisted_foods, through: :wishlist_foods, source: :food
 
   def wishlist(food)
-    wishlist_foods << food
+    wishlisted_foods << food
   end
 
   def unwishlist(food)
-    wishlist_foods.destroy(food)
+    wishlisted_foods.destroy(food)
   end
 
   def wishlist?(food)
-    wishlist_foods.include?(food)
+    wishlisted_foods.include?(food)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,20 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   enum role: { general: 0, admin: 1 }
+
+  has_many :foods, dependent: :destroy
+  has_many :wishlist_foods, dependent: :destroy
+  has_many :wishlisted_foods, through: :wishlist_foods, source: :food
+
+  def wishlist(food)
+    wishlist_foods << food
+  end
+
+  def unwishlist(food)
+    wishlist_foods.destroy(food)
+  end
+
+  def wishlist?(food)
+    wishlist_foods.include?(food)
+  end
 end

--- a/app/models/wishlist_food.rb
+++ b/app/models/wishlist_food.rb
@@ -1,0 +1,6 @@
+class WishlistFood < ApplicationRecord
+  belongs_to :user
+  belongs_to :food
+
+  validates :user_id, uniqueness: { scope: :food_id }
+end

--- a/app/models/wishlist_food.rb
+++ b/app/models/wishlist_food.rb
@@ -2,5 +2,5 @@ class WishlistFood < ApplicationRecord
   belongs_to :user
   belongs_to :food
 
-  validates :user_id, uniqueness: { scope: :food_id }
+  validates :food_id, uniqueness: { scope: :user_id }
 end

--- a/app/views/foods/_food_card.html.erb
+++ b/app/views/foods/_food_card.html.erb
@@ -1,29 +1,26 @@
-<%= link_to food_path(food), class: "block" do %>
-  <div class="bg-white rounded-xl shadow hover:shadow-lg overflow-hidden">
-    <!-- 画像 -->
+<div class="bg-white rounded-xl shadow hover:shadow-lg overflow-hidden">
+  <%= link_to food_path(food), class: "block" do %>
+      <!-- 画像 -->
     <div>
       <%= image_tag(food.image_url || "sample.png", class: "w-full aspect-square object-cover") %>
     </div>
-
+  <% end %>
     <!-- 本文 -->
-    <div class="p-3">
-      <div class="flex items-start">
-        <!-- 食材名 -->
-        <p class="text-lg font-semibold line-clamp-2 flex-grow">
-          <%= food.name %>
-        </p>
-        <!-- 「食べたい」(ブックマーク) -->
-        <button class="text-red-400 text-2xl leading-none ml-2">
-          ♥
-        </button>
-      </div>
-      <!-- レア度 -->
-      <p class="text-m font-semibold text-gray-800 mt-1">
-        レア度：
-        <span class="font-bold tracking-wide text-yellow-400 drop-shadow">
-          <%= "♦" * food.rarity_before_type_cast %>
-        </span>
+  <div class="p-3">
+    <div class="flex items-start">
+      <!-- 食材名 -->
+      <p class="text-lg font-semibold line-clamp-2 flex-grow">
+        <%= food.name %>
       </p>
+      <!-- 「食べたい」(ブックマーク) -->
+      <%= render 'wishlist_buttons', { food: food } %>
     </div>
+    <!-- レア度 -->
+    <p class="text-m font-semibold text-gray-800 mt-1">
+      レア度：
+      <span class="font-bold tracking-wide text-yellow-400 drop-shadow">
+        <%= "♦" * food.rarity_before_type_cast %>
+      </span>
+    </p>
   </div>
-<% end %>
+</div>

--- a/app/views/foods/_unwishlist.html.erb
+++ b/app/views/foods/_unwishlist.html.erb
@@ -1,0 +1,5 @@
+<%= link_to wishlist_food_path(current_user.wishlist_foods.find_by(food_id: food.id)),
+            id: "unwishlist-button-for-food-#{food.id}",
+            data: { turbo_method: :delete } do %>
+  <i class="bi bi-heart-fill"></i>
+<% end %>

--- a/app/views/foods/_wishlist.html.erb
+++ b/app/views/foods/_wishlist.html.erb
@@ -1,0 +1,5 @@
+<%= link_to wishlist_foods_path(food_id: food.id),
+            id: "wishlist-button-for-food-#{food.id}",
+            data: { turbo_method: :post } do %>
+  <i class="bi bi-heart"></i>
+<% end %>

--- a/app/views/foods/_wishlist_buttons.html.erb
+++ b/app/views/foods/_wishlist_buttons.html.erb
@@ -1,0 +1,7 @@
+<div class="text-red-400 text-2xl leading-none ml-2">
+  <% if current_user.wishlist?(food) %>
+    <%= render "unwishlist", { food: food } %>
+  <% else %>
+    <%= render "wishlist", { food: food } %>
+  <% end %>
+</div>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -28,9 +28,7 @@
           食べた
         </button>
         <!-- 「食べたい」(ブックマーク) -->
-        <button class="text-red-400 text-2xl leading-none ml-2">
-          ♥
-        </button>
+        <%= render 'wishlist_buttons', { food: @food } %>
       </div>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>

--- a/app/views/wishlist_foods/create.turbo_stream.erb
+++ b/app/views/wishlist_foods/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "wishlist-button-for-food-#{@food.id}" do %>
+  <%= render 'foods/unwishlist', food: @food %>
+<% end %>

--- a/app/views/wishlist_foods/destroy.turbo_stream.erb
+++ b/app/views/wishlist_foods/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "unwishlist-button-for-food-#{@food.id}" do %>
+  <%= render 'foods/wishlist', food: @food %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,10 @@ Rails.application.routes.draw do
 
   root "foods#index"
   devise_for :users
-  resources :foods, only: %i[index show]
+  resources :foods, only: %i[index show] do
+    collection do
+      get :wishlist_foods
+    end
+  end
+  resources :wishlist_foods, only: %i[create destroy]
 end

--- a/db/migrate/20260428013519_create_wishlist_foods.rb
+++ b/db/migrate/20260428013519_create_wishlist_foods.rb
@@ -6,6 +6,6 @@ class CreateWishlistFoods < ActiveRecord::Migration[7.2]
 
       t.timestamps
     end
-    add_index :wishlist_foods, [:user_id, :food_id], unique: true
+    add_index :wishlist_foods, [ :user_id, :food_id ], unique: true
   end
 end

--- a/db/migrate/20260428013519_create_wishlist_foods.rb
+++ b/db/migrate/20260428013519_create_wishlist_foods.rb
@@ -1,0 +1,11 @@
+class CreateWishlistFoods < ActiveRecord::Migration[7.2]
+  def change
+    create_table :wishlist_foods do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :food, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :wishlist_foods, [:user_id, :food_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_23_081021) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_28_013519) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,5 +46,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_23_081021) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "wishlist_foods", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "food_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["food_id"], name: "index_wishlist_foods_on_food_id"
+    t.index ["user_id", "food_id"], name: "index_wishlist_foods_on_user_id_and_food_id", unique: true
+    t.index ["user_id"], name: "index_wishlist_foods_on_user_id"
+  end
+
   add_foreign_key "foods", "categories"
+  add_foreign_key "wishlist_foods", "foods"
+  add_foreign_key "wishlist_foods", "users"
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    sequence(:name) { |n| "カテゴリー#{n}" }
+  end
+end

--- a/spec/factories/foods.rb
+++ b/spec/factories/foods.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :food do
+    sequence(:name) { |n| "食材#{n}" }
+    rarity { :common }
+    association :category
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :user do
+    email { Faker::Internet.unique.email }
+    password { 'password' }
+    password_confirmation { 'password' }
+  end
+
+  trait :general do
+    role { :general }
+  end
+
+  trait :admin do
+    role { :admin }
+  end
+end

--- a/spec/factories/wishlist_foods.rb
+++ b/spec/factories/wishlist_foods.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :wishlist_food do
+    association :user
+    association :food
+  end
+end

--- a/spec/models/wishlist_food_spec.rb
+++ b/spec/models/wishlist_food_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe WishlistFood, type: :model do
   subject { build(:wishlist_food) }
-  
+
   it { should belong_to(:user) } # userに属している
   it { should belong_to(:food) } # foodに属している
   it { should validate_uniqueness_of(:food_id).scoped_to(:user_id) } # user単位で重複しない

--- a/spec/models/wishlist_food_spec.rb
+++ b/spec/models/wishlist_food_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe WishlistFood, type: :model do
+  subject { build(:wishlist_food) }
+  
+  it { should belong_to(:user) } # userに属している
+  it { should belong_to(:food) } # foodに属している
+  it { should validate_uniqueness_of(:food_id).scoped_to(:user_id) } # user単位で重複しない
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,6 +69,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
## 概要
「食べたい」（お気に入り）機能実装

## 背景
「食べたい」追加・削除機能 #16

## 変更内容
- `wishlist_foods`テーブルを作成
- `wishlist_food`モデルを追加
- `Bootstrap Icons` の CDN を追加
- 「食べたい」機能実装

## 確認方法
1. 食材一覧ページのカードに♡が表示され、クリックすると表示が切り替わること
2. 食材詳細ページのカードに♡が表示され、クリックすると表示が切り替わること
3. ♡をクリックすると`wishlist_foods`にレコードが作成されること

## 影響範囲
- 食材一覧ページ
- 食材詳細ページ

## 補足
もともとボタンで置いていた♥を`Bootstrap Icons` のハートマークにrenderで差し替えた際に、食材一覧のカード表示が格子状に配置されてしまった。
元の表示に戻すのにビューを調整することで苦慮した。