### PR TITLE
feature/17-wishlist-foods-index

### DIFF
--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -6,4 +6,8 @@ class FoodsController < ApplicationController
   def show
     @food = Food.find(params[:id])
   end
+
+  def wishlist_foods
+    @foods = current_user.wishlisted_foods.includes(:category).order(created_at: :desc)
+  end
 end

--- a/app/views/foods/wishlist_foods.html.erb
+++ b/app/views/foods/wishlist_foods.html.erb
@@ -1,0 +1,32 @@
+<% @foods.each do |food| %>
+  <div class="bg-white rounded-lg shadow mb-4 overflow-hidden max-w-3xl mx-auto">
+    <div class="flex justify-start">
+      <!-- 左：画像 -->
+      <div class="w-1/4 aspect-square overflow-hidden rounded-l-lg">
+        <%= image_tag food.image_url, class: "w-full h-full rounded-xl object-cover" %>
+      </div>
+      <!-- 右：情報 -->
+      <div class="w-2/3 p-4 flex flex-col justify-between">
+        <div>
+          <p class="text-xl font-bold"><%= food.name %></p>
+          <p class="text-lg font-bold text-gray-500"><%= food.category.name %></p>
+          <!-- レア度 -->
+          <div class="text-lg font-semibold text-gray-800">
+            レア度：
+            <span class="font-bold tracking-wide text-yellow-400 drop-shadow text-lg">
+              <%= "♦" * food.rarity_before_type_cast %>
+            </span>
+          </div>
+        </div>
+        <div class="flex items-center gap-4 mt-3">
+          <!-- 食べたボタン -->
+          <button class= "px-4 py-2 bg-green-600 text-white font-semibold rounded-lg shadow hover:bg-green-700">
+            食べた
+          </button>
+          <!-- 「食べたい」(ブックマーク) -->
+          <%= render 'wishlist_buttons', food: food %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,7 @@
   <%= image_tag "shokutan_logo.png", alt: "食探ロゴ", class: "h-20 w-auto" %>
   <div class="flex gap-4">
     <%= link_to "食材一覧", root_path, class: "text-gray-700 hover:text-black" %>
-    <%= link_to "「食べたい」リスト", '#', class: "text-gray-700 hover:text-black" %>
+    <%= link_to "「食べたい」リスト", wish_list_foods_path, class: "text-gray-700 hover:text-black" %>
     <%= link_to "「食べた」リスト", '#', class: "text-gray-700 hover:text-black" %>
     <%= link_to "レビュー一覧", '#', class: "text-gray-700 hover:text-black" %>
     <%= link_to "ログアウト", destroy_user_session_path, class: 'dropdown-item', data: { turbo_method: :delete } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   devise_for :users
   resources :foods, only: %i[index show] do
     collection do
-      get :wishlist_foods
+      get :wishlist_foods, as: :wish_list
     end
   end
   resources :wishlist_foods, only: %i[create destroy]


### PR DESCRIPTION
## 概要
「食べたい」食材一覧ページを実装しました。

## 背景
「食べたい」食材一覧表示 #17

## 変更内容
- ヘッダーの「食べたい」リスト導線作成
- 「食べたい」食材一覧ページの作成

## 確認方法
1. ヘッダーの「食べたい」リストをクリックすると「食べたい」食材一覧ページが表示されること
2. 「食べたい」食材一覧ページにアクセスできること
3. 「食べたい」食材に加えた食材が、「食べたい」食材一覧ページに表示されること

## 影響範囲
- ヘッダー
- 「食べたい」食材一覧ページ

## 補足
ルーティングで`collection`を使って`get :wishlist_foods`としたがヘルパー名が`wishlist_foods_foods_path`と`foods`が重複してしまうため、`as: :wish_list`とした。