### PR TITLE
feature/18-eaten-food

### DIFF
--- a/app/controllers/eaten_foods_controller.rb
+++ b/app/controllers/eaten_foods_controller.rb
@@ -1,0 +1,6 @@
+class EatenFoodsController < ApplicationController
+  def new
+    @food = Food.find(params[:food_id])
+    @eaten_food = current_user.eaten_foods.new(food: @food)
+  end
+end

--- a/app/controllers/eaten_foods_controller.rb
+++ b/app/controllers/eaten_foods_controller.rb
@@ -3,4 +3,19 @@ class EatenFoodsController < ApplicationController
     @food = Food.find(params[:food_id])
     @eaten_food = current_user.eaten_foods.new(food: @food)
   end
+
+  def create
+    @eaten_food = current_user.eaten_foods.new(eaten_food_params)
+    if @eaten_food.save
+      redirect_to "#"
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def eaten_food_params
+    params.require(:eaten_food).permit(:food_id, :ate_on)
+  end
 end

--- a/app/models/eaten_food.rb
+++ b/app/models/eaten_food.rb
@@ -1,0 +1,6 @@
+class EatenFood < ApplicationRecord
+  belongs_to :user
+  belongs_to :food, optional: true
+
+  validates :user_id, presence: true
+end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -4,4 +4,5 @@ class Food < ApplicationRecord
 
   belongs_to :category
   has_many :wishlist_foods, dependent: :destroy
+  has_many :eaten_foods, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :foods, dependent: :destroy
   has_many :wishlist_foods, dependent: :destroy
   has_many :wishlisted_foods, through: :wishlist_foods, source: :food
+  has_many :eaten_foods, dependent: :destroy
 
   def wishlist(food)
     wishlisted_foods << food
@@ -19,5 +20,17 @@ class User < ApplicationRecord
 
   def wishlist?(food)
     wishlisted_foods.include?(food)
+  end
+
+  def eat(food, ate_on: Date.today, custom_name: nil)
+    eaten_foods.create(food: food, ate_on: ate_on, custom_name: custom_name)
+  end
+
+  def uneat(eaten_food)
+    eaten_foods.destroy(eaten_food)
+  end
+
+  def eaten?(food, ate_on: Date.today)
+    eaten_foods.exists?(food: food, ate_on: ate_on)
   end
 end

--- a/app/views/eaten_foods/_eaten_button.html.erb
+++ b/app/views/eaten_foods/_eaten_button.html.erb
@@ -1,0 +1,6 @@
+<%= link_to new_eaten_food_path(food_id: food.id),
+              method: :get,
+              data: { turbo_stream: true },
+              class: "px-4 py-2 bg-green-600 text-white font-semibold rounded-lg shadow hover:bg-green-700" do %>
+  食べた
+<% end %>

--- a/app/views/eaten_foods/_form.html.erb
+++ b/app/views/eaten_foods/_form.html.erb
@@ -1,0 +1,10 @@
+<div class="p-4 bg-white rounded shadow mt-1">
+  <h1 class="font-bold mb-2">食べた日を入力</h1>
+  <%= form_with model: @eaten_food, url: eaten_foods_path, data: { turbo_stream: true } do |f| %>
+    <%= f.hidden_field :food_id, value: food.id %>
+    <div class="mb-2">
+      <%= f.date_field :ate_on, value: Date.today, class: "border rounded px-2 py-1" %>
+    </div>
+    <%= f.submit "保存", class: "px-4 py-2 bg-blue-600 text-white rounded" %>
+  <% end %>
+</div>

--- a/app/views/eaten_foods/new.turbo_stream.erb
+++ b/app/views/eaten_foods/new.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "eaten-food-form-#{@food.id}" do %>
+  <%= render "form", food: @food %>
+<% end %>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -24,17 +24,17 @@
       </p>
       <div class="flex items-center gap-4 mt-3">
         <!-- 食べたボタン -->
-        <button class= "px-4 py-2 bg-green-600 text-white font-semibold rounded-lg shadow hover:bg-green-700">
-          食べた
-        </button>
+        <%= render 'eaten_foods/eaten_button', { food: @food } %>
         <!-- 「食べたい」(ブックマーク) -->
         <%= render 'wishlist_buttons', { food: @food } %>
       </div>
+      <!-- 食べたボタン日付入力フォーム -->
+      <div id="eaten-food-form-<%= @food.id %>"></div>
     </div>
   </div>
   <!-- 特徴 -->
   <div class="mt-6">
-    <h2 class="text-lg font-semibold mb-2">特徴</h2>
+    <h1 class="text-lg font-semibold mb-2">特徴</h1>
     <p class="text-gray-700 leading-relaxed">
       <%= @food.description %>
     </p>

--- a/app/views/foods/wishlist_foods.html.erb
+++ b/app/views/foods/wishlist_foods.html.erb
@@ -8,7 +8,7 @@
       <!-- 右：情報 -->
       <div class="w-2/3 p-4 flex flex-col justify-between">
         <div>
-          <p class="text-xl font-bold"><%= food.name %></p>
+          <h1 class="text-xl font-bold"><%= food.name %></h1>
           <p class="text-lg font-bold text-gray-500"><%= food.category.name %></p>
           <!-- レア度 -->
           <div class="text-lg font-semibold text-gray-800">
@@ -20,12 +20,12 @@
         </div>
         <div class="flex items-center gap-4 mt-3">
           <!-- 食べたボタン -->
-          <button class= "px-4 py-2 bg-green-600 text-white font-semibold rounded-lg shadow hover:bg-green-700">
-            食べた
-          </button>
+          <%= render 'eaten_foods/eaten_button', { food: food } %>
           <!-- 「食べたい」(ブックマーク) -->
           <%= render 'wishlist_buttons', food: food %>
         </div>
+        <!-- 食べたボタン日付入力フォーム -->
+        <div id="eaten-food-form-<%= food.id %>" class= "mt-6"></div>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,5 @@ Rails.application.routes.draw do
     end
   end
   resources :wishlist_foods, only: %i[create destroy]
+  resources :eaten_foods, only: %i[new create]
 end

--- a/db/migrate/20260429142547_create_eaten_foods.rb
+++ b/db/migrate/20260429142547_create_eaten_foods.rb
@@ -1,0 +1,12 @@
+class CreateEatenFoods < ActiveRecord::Migration[7.2]
+  def change
+    create_table :eaten_foods do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :food, foreign_key: true
+      t.string :custom_name
+      t.date :ate_on
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_28_013519) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_29_142547) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_28_013519) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_categories_on_name", unique: true
+  end
+
+  create_table "eaten_foods", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "food_id"
+    t.string "custom_name"
+    t.date "ate_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["food_id"], name: "index_eaten_foods_on_food_id"
+    t.index ["user_id"], name: "index_eaten_foods_on_user_id"
   end
 
   create_table "foods", force: :cascade do |t|
@@ -56,6 +67,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_28_013519) do
     t.index ["user_id"], name: "index_wishlist_foods_on_user_id"
   end
 
+  add_foreign_key "eaten_foods", "foods"
+  add_foreign_key "eaten_foods", "users"
   add_foreign_key "foods", "categories"
   add_foreign_key "wishlist_foods", "foods"
   add_foreign_key "wishlist_foods", "users"

--- a/spec/models/eaten_food_spec.rb
+++ b/spec/models/eaten_food_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe EatenFood, type: :model do
+  it { should belong_to(:user) } # userに属している
+  it { should belong_to(:food).optional } # foodが存在する場合は属している
+  it { is_expected.to validate_presence_of(:user_id) } # user_idは重複しない
+end


### PR DESCRIPTION
## 概要
「食べた」食材保存機能を実装しました。

## 背景
「食べた」食材保存機能 #18

## 変更内容
- eaten_foodsテーブルを作成
- eaten_foodモデルを追加
- 「食べた」食材保存機能実装

## 確認方法
1. 食材詳細ページのカードに「食べた」ボタンが表示され、クリックすると日付入力フォームが表示されること
2. 「食べたい」リストページのカードに「食べた」ボタンが表示され、クリックすると日付入力フォームが表示されること
3. 日付入力フォームから保存ボタンを押すと、`eaten_foods`にレコードが作成されること

## 影響範囲
- 食材詳細ページ
- 「食べたい」リストページ

## 補足
`turbo_stream`レスポンスが正しく返らず、「食べた」ボタンを押しても日付入力フォームが表示されず、問題を解消することに苦慮しました。