### PR TITLE
fix/48-auth-hide-buttons-and-index-error

### DIFF
--- a/app/views/foods/_food_card.html.erb
+++ b/app/views/foods/_food_card.html.erb
@@ -12,8 +12,10 @@
       <p class="text-lg font-semibold line-clamp-2 flex-grow">
         <%= food.name %>
       </p>
-      <!-- 「食べたい」(ブックマーク) -->
-      <%= render 'wishlist_buttons', { food: food } %>
+      <% if user_signed_in? %>
+        <!-- 「食べたい」(ブックマーク) -->
+        <%= render 'wishlist_buttons', { food: food } %>
+      <% end %>
     </div>
     <!-- レア度 -->
     <p class="text-m font-semibold text-gray-800 mt-1">

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -22,14 +22,16 @@
           <%= "♦" * @food.rarity_before_type_cast %>
         </span>
       </p>
-      <div class="flex items-center gap-4 mt-3">
-        <!-- 食べたボタン -->
-        <%= render 'eaten_foods/eaten_button', { food: @food } %>
-        <!-- 「食べたい」(ブックマーク) -->
-        <%= render 'wishlist_buttons', { food: @food } %>
-      </div>
-      <!-- 食べたボタン日付入力フォーム -->
-      <div id="eaten-food-form-<%= @food.id %>"></div>
+      <% if user_signed_in? %>
+        <div class="flex items-center gap-4 mt-3">
+          <!-- 食べたボタン -->
+          <%= render 'eaten_foods/eaten_button', { food: @food } %>
+          <!-- 「食べたい」(ブックマーク) -->
+          <%= render 'wishlist_buttons', { food: @food } %>
+        </div>
+        <!-- 食べたボタン日付入力フォーム -->
+        <div id="eaten-food-form-<%= @food.id %>"></div>
+      <% end %>
     </div>
   </div>
   <!-- 特徴 -->


### PR DESCRIPTION
## 概要
未ログイン時とログイン時で表示される UI を切り替える処理を追加しました。


## 背景
食材一覧ページが未ログイン時にエラーになってしまう問題の修正 #48

## 変更内容
- `user_signed_in?` を用いた表示切り替え処理をトップページの食材カードと食材詳細ページに追加

## 確認方法
1. 未ログイン状態でトップページを表示  
    - ハートマークが表示されないこと
2. ログイン後にトップページを表示  
   - 「食べた」ボタン、ハートマークが表示されること
   - ボタンが正常に動作すること
3. 未ログイン状態で食材詳細ページを表示  
   - ハートマークが表示されないこと
2. ログイン後に食材詳細ページを表示  
   - 「食べた」ボタン、ハートマークが表示されること
   - ボタンが正常に動作すること

## 影響範囲
- トップページ
- 食材詳細ページ

## 補足
ログイン/未ログインで UI を分ける必要がある際は注意しなければならない。