### PR TITLE
feature/49-auth-filter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+  before_action :authenticate_user!
   rescue_from CanCan::AccessDenied, with: :user_not_authorized # admin権限がない場合はエラーページを返す
 
   private

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -1,4 +1,6 @@
 class FoodsController < ApplicationController
+  skip_before_action :authenticate_user!, only: %i[index show]
+
   def index
     @foods = Food.all
   end


### PR DESCRIPTION
## 概要
アプリの認証処理を実装しました。

## 背景
認証処理の追加 #49

## 変更内容
- `ApplicationController`に`before_action :authenticate_user!` を追加
- 公開ページ用に`FoodsController`に`skip_before_action :authenticate_user!, only: %i[index show]`を追加

## 確認方法
1. 未ログイン時に新規登録ページ、ログインページ、食材一覧ページ、食材詳細ページにアクセスできること
2. 未ログイン時に上記以外のページにアクセスした際、ログインページにリダイレクトされること

## 影響範囲
- 全てのコントローラー

## 補足
公開ページが増える場合は、各コントローラーで`skip_before_action :authenticate_user!`を追加する必要がある。