### PR TITLE
feature/19-eaten-foods-index

### DIFF
--- a/app/controllers/eaten_foods_controller.rb
+++ b/app/controllers/eaten_foods_controller.rb
@@ -1,4 +1,8 @@
 class EatenFoodsController < ApplicationController
+  def index
+    @eaten_foods = current_user.eaten_foods.includes(:food).order(ate_on: :desc)
+  end
+
   def new
     @food = Food.find(params[:food_id])
     @eaten_food = current_user.eaten_foods.new(food: @food)

--- a/app/views/eaten_foods/index.html.erb
+++ b/app/views/eaten_foods/index.html.erb
@@ -1,0 +1,30 @@
+<div class="container mx-auto pt-3">
+  <% @eaten_foods.each do |eaten| %>
+    <div class="bg-white rounded-lg shadow p-4 mb-3 flex items-center justify-between max-w-3xl w-full mx-auto">
+      <!-- 食材名 -->
+      <div class="w-1/4">
+        <p class="text-lg font-bold"><%= eaten.food.name %></p>
+      </div>
+      <!-- 満足度 -->
+      <div class="w-1/6 text-center">
+        <p class="text-gray-800 font-semibold">
+          満足度:
+        </p>
+      </div>
+      <!-- 食べた日 -->
+      <div class="w-1/4 text-center">
+        <p class="text-gray-800">
+          食べた日: <%= eaten.ate_on %>
+        </p>
+      </div>
+      <!-- レビューを書く -->
+      <div class="w-1/6 text-center">
+        <%= link_to "レビューを書く", '#', class: "inline-flex items-center gap-2 border border-gray-400 text-gray-800 font-bold bg-white px-3 py-1.5 rounded-md hover:bg-gray-100 text-sm" %>
+      </div>
+      <!-- ゴミ箱（Bootstrap Icons） -->
+      <div class="w-12 text-center">
+        <button class="bi bi-trash"></button>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
   <div class="flex gap-4">
     <%= link_to "食材一覧", root_path, class: "text-gray-700 hover:text-black" %>
     <%= link_to "「食べたい」リスト", wish_list_foods_path, class: "text-gray-700 hover:text-black" %>
-    <%= link_to "「食べた」リスト", '#', class: "text-gray-700 hover:text-black" %>
+    <%= link_to "「食べた」リスト", eaten_foods_path, class: "text-gray-700 hover:text-black" %>
     <%= link_to "レビュー一覧", '#', class: "text-gray-700 hover:text-black" %>
     <%= link_to "ログアウト", destroy_user_session_path, class: 'dropdown-item', data: { turbo_method: :delete } %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,5 +21,5 @@ Rails.application.routes.draw do
     end
   end
   resources :wishlist_foods, only: %i[create destroy]
-  resources :eaten_foods, only: %i[new create]
+  resources :eaten_foods, only: %i[index new create]
 end


### PR DESCRIPTION
## 概要
「食べた」食材一覧ページを実装しました。

## 背景
「食べた」リスト一覧表示 #19

## 変更内容
- ヘッダーの「食べた」リスト導線作成
- 「食べた」食材一覧ページの作成

## 確認方法
1. ヘッダーの「食べた」リストをクリックすると「食べた」食材一覧ページが表示されること
2. 「食べた」食材一覧ページにアクセスできること
3. 「食べた」食材に加えた食材が、「食べた」食材一覧ページに表示されること

## 影響範囲
- ヘッダー
- 「食べた」食材一覧ページ

## 補足
「食べた」食材削除機能、満足度の表示、レビュー機能は別PRで実装予定。