### PR TITLE
feature/20-eaten-foods-destroy

### DIFF
--- a/app/controllers/eaten_foods_controller.rb
+++ b/app/controllers/eaten_foods_controller.rb
@@ -17,6 +17,12 @@ class EatenFoodsController < ApplicationController
     end
   end
 
+  def destroy
+    eaten_food = current_user.eaten_foods.find(params[:id])
+    eaten_food.destroy!
+    redirect_to eaten_foods_path
+  end
+
   private
 
   def eaten_food_params

--- a/app/views/eaten_foods/index.html.erb
+++ b/app/views/eaten_foods/index.html.erb
@@ -17,13 +17,15 @@
           食べた日: <%= eaten.ate_on %>
         </p>
       </div>
-      <!-- レビューを書く -->
+      <!-- レビューボタン -->
       <div class="w-1/6 text-center">
         <%= link_to "レビューを書く", '#', class: "inline-flex items-center gap-2 border border-gray-400 text-gray-800 font-bold bg-white px-3 py-1.5 rounded-md hover:bg-gray-100 text-sm" %>
       </div>
-      <!-- ゴミ箱（Bootstrap Icons） -->
+      <!-- 削除ボタン -->
       <div class="w-12 text-center">
-        <button class="bi bi-trash"></button>
+        <%= link_to eaten_food_path(eaten), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } do %>
+          <i class="bi bi-trash"></i>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,5 +21,5 @@ Rails.application.routes.draw do
     end
   end
   resources :wishlist_foods, only: %i[create destroy]
-  resources :eaten_foods, only: %i[index new create]
+  resources :eaten_foods, only: %i[index new create destroy]
 end


### PR DESCRIPTION
## 概要
「食べた」食材削除機能を実装しました。

## 背景
「食べた」削除機能 #20

## 変更内容
-  `eaten_foods`の`destroy`アクションを実装
-  削除後のリダイレクト先を`eaten_foods_path`に設定

## 確認方法
1. 「食べた」リストページへアクセス
2.  任意の食材のゴミ箱アイコンをクリック
3. 「削除しますか？」の確認後、対象食材が削除されること

## 影響範囲
- 「食べた」リストページ

## 補足
フラッシュメッセージは別PRにて対応予定