### PR TITLE
fix/55-raty-js-jQuery

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "raty", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
   </head>
 
   <body class="bg-[#F2EEE3] min-h-screen flex flex-col">


### PR DESCRIPTION
## 概要
jQueryを導入しました。

## 背景
raty-jsの不具合修正 #55

## 変更内容
- `application.html.erb`にjQueryのCDNを追加

## 確認方法
- 開発者ツールのConsoleで`typeof jQuery`と入力し、`function`と返ること

## 影響範囲
- `application.html.erb`

## 補足
CDNを誤って削除してしまっていたため、再度追加します。