### PR TITLE
fix/58-raty-not-working-without-reload

### DIFF
--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -7,9 +7,9 @@
       <div class="field mb-2">
         <p><%= f.label :satisfaction, "満足度", class: "block text-sm font-medium text-gray-700" %></p>
         <!-- ratyを描画 -->
-        <div id="star_<%= @review.id %>" class="raty"></div>
+        <div id="star_new" class="raty"></div>
         <!-- 実際に送信される値 -->
-        <%= f.hidden_field :satisfaction, id: "satisfaction_#{@review.id}" %>
+        <%= f.hidden_field :satisfaction, id: "satisfaction_new" %>
       </div>
 
       <div class="field">
@@ -26,11 +26,13 @@
 
 <script>
 document.addEventListener("turbo:load", () => {
-  const elem = document.querySelector("#star_<%= @review.id %>");
+  const elem = document.querySelector("#star_new");
   if (!elem) return;
 
-  const hidden = document.querySelector("#satisfaction_<%= @review.id %>");
+  const hidden = document.querySelector("#satisfaction_new");
 
+  elem.removeAttribute("data-read-only");
+  elem.removeAttribute("style");
   elem.innerHTML = "";
 
   window.raty(elem, {


### PR DESCRIPTION
## 概要
raty-jsのページをリロードしないと動かない不具合を修正しました。

## 背景
raty-jsのページをリロードしないと動かない不具合修正 #58

## 変更内容
- `views/reviews/html.erb`の`raty-js script`に下記の処理を追加
  ```
  elem.removeAttribute("data-read-only");
  elem.removeAttribute("style");
  ```

## 確認方法
- レビュー投稿ページで`raty`がリロードせずに満足度を入力できること

## 影響範囲
- レビュー投稿ページ

## 補足
表示はできていたので初期化で不具合が起きていると推測はできたが、原因を突き止めることがとても難しく感じた。