### PR TITLE
feature/69-improve-feedback-add

### DIFF
--- a/app/views/eaten_foods/index.html.erb
+++ b/app/views/eaten_foods/index.html.erb
@@ -26,7 +26,7 @@
         <!-- レビューボタン -->
         <div class="w-1/5 text-center">
           <% if eaten.review.present? %>
-            <p class="text-gray-800 font-semibold">未レビュー</p>
+            <p class="text-gray-800 font-semibold">レビュー済み</p>
             <!-- <%= link_to "レビューを編集", '#', class: "inline-flex items-center gap-2 border border-gray-400 text-gray-800 font-bold bg-white px-3 py-1.5 rounded-md hover:bg-gray-100 text-sm" %> -->
           <% else %>
             <%= link_to "レビューを書く", new_eaten_food_review_path(eaten_food_id: eaten.id), class: "inline-flex items-center gap-2 border border-gray-400 text-gray-800 font-bold bg-white px-3 py-1.5 rounded-md hover:bg-gray-100 text-sm" %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,7 +1,7 @@
 <% if object.errors.any? %>
   <div id="error_explanation" class="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 text-red-800">
     <h2 class="mb-2 font-semibold">
-      <%= pluralize(object.errors.count, "error") %> prohibited this record from being saved:
+      <%= object.errors.count %>件のエラーがあります、入力内容を確認してください
     </h2>
     <ul class="list-disc space-y-1 pl-5 text-sm">
       <% object.errors.each do |error| %>


### PR DESCRIPTION
## 概要
新規登録時のエラーメッセージ文言と、「食べた」リストのレビュー済み時の文言修正

## 背景
pushし忘れの追加 #69

## 変更内容
- エラーメッセージが英語になっていたため日本語に修正
- 「食べた」リストのレビュー済み食材に「未レビュー」が表示されていたので「レビュー済み」に修正

## 確認方法
1. 新規登録時のエラーメッセージが日本語で表示されること
2. 「食べた」リストのレビュー済み食材に「レビュー済み」が表示されること

## 影響範囲
- 新規登録ページ
- 「食べた」リストページ

## 補足
コミットでステージングしたものがプッシュされてるかよく確認すること