### PR TITLE
feature/71-food-detail-review

### DIFF
--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -44,9 +44,8 @@
   <!-- レビュー情報 -->
   <div class="mt-6">
     <h1 class="text-lg font-semibold mb-2">レビュー一覧</h1>
-    <% if @eaten_foods.present? %>
+    <% if @eaten_foods.any? %>
       <% @eaten_foods.each do |eaten_food| %>
-        <% next if eaten_food.review.blank? %>
         <div class="mt-4 p-4 rounded-lg border border-gray-200 w-full h-auto">
           <!-- 食べた日 + 満足度 -->
           <div class="flex items-center gap-6 mb-3">
@@ -62,6 +61,10 @@
           </p>
         </div>
       <% end %>
+    <% else %>
+      <div class="text-center font-bold text-gray-600 text-lg py-10">
+        レビューがありません
+      </div>
     <% end %>
   </div>
 


### PR DESCRIPTION
## 概要
食材詳細ページにその食材のレビューが存在しない場合にメッセージを表示するようにしました。

## 背景
食材詳細画面のレビュー表示挙動の変更 #71

## 変更内容
- 食材詳細ページにその食材のレビューが存在しない場合に「レビューがありません」と表示

## 確認方法
- レビューがない食材詳細ページにアクセスし、レビュー一覧に「レビューがありません」と表示されること

## 影響範囲
- 食材詳細ページ

## 補足
デザインは改めて変更するかもしれません。