### PR TITLE
fix/100-guest-food-show-access

### DIFF
--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -10,6 +10,8 @@ class FoodsController < ApplicationController
 
     if user_signed_in?
       @eaten_foods = current_user.eaten_foods.where(food_id: @food.id).joins(:review).includes(:review).order(ate_on: :desc)
+    else
+      @eaten_foods = EatenFood.none
     end
   end
 


### PR DESCRIPTION
## 概要
未ログイン時食材詳細画面が開けない不具合を修正

## 背景
未ログイン時食材詳細画面が開けない不具合修正 #100 

## 変更内容
- 未ログイン時に`@eaten_foods`を`EatenFood.none`で初期化するよう修正

## 確認方法
1. 未ログイン状態で食材詳細ページにアクセス
2. ページがエラーなく表示されること

## 影響範囲
- 食材詳細ページ

## 補足
未ログイン状態で食材詳細ページにアクセスすると`@eaten_foods`がセットされず`nil`となってしまっていた