### PR TITLE
feature/79-reviews-destroy

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -18,6 +18,13 @@ class ReviewsController < ApplicationController
     end
   end
 
+  def destroy
+    eaten_food = current_user.eaten_foods.find(params[:eaten_food_id])
+    review = eaten_food.review
+    review.destroy!
+    redirect_to reviews_path, notice: "レビューを削除しました"
+  end
+
   private
 
   def review_params

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -24,7 +24,7 @@
             <!-- 編集ボタン -->
             <%= link_to "レビューを編集", '#', class: "inline-flex items-center gap-2 border border-gray-400 text-gray-800 font-bold bg-white px-3 py-1.5 rounded-md hover:bg-gray-100 text-sm" %>
             <!-- 削除ボタン -->
-            <%= link_to "削除", '#',
+            <%= link_to "削除", eaten_food_review_path(eaten),
                   data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
                   class: "inline-flex items-center gap-2 bg-red-600 text-white font-bold px-3 py-1.5 rounded-md hover:bg-red-700 text-sm" %>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
   end
   resources :wishlist_foods, only: %i[create destroy]
   resources :eaten_foods, only: %i[index new create destroy] do
-    resource :review, only: %i[new create]
+    resource :review, only: %i[new create destroy]
   end
   resources :reviews, only: %i[index]
 end


### PR DESCRIPTION
## 概要
レビュー削除機能を実装しました。

## 背景
レビュー削除機能 #79

## 変更内容
- `reviews`の`destroy`アクションを実装
- 削除後のリダイレクト先を`reviews_path`に設定

## 確認方法
- レビュー一覧からレビューの「削除」ボタンを押すと、レビュー一覧から該当レビューが削除されること

## 影響範囲
- レビュー一覧ページ

## 補足
フラッシュメッセージは別PRにて調整予定