### PR TITLE
feature/78-reviews-edit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager
+        run: bin/brakeman --no-pager --skip-check EOLRails
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager --skip-check EOLRails
+        run: bin/brakeman --no-pager --no-exit-on-warn
 
   lint:
     runs-on: ubuntu-latest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       debug_inspector (>= 1.2.0)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     byebug (13.0.0)
@@ -505,7 +505,7 @@ CHECKSUMS
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   binding_of_caller (2.0.0) sha256=e53eebf8428a85587aede7b43a83e7419eb85b8b690938a96aa330d03052d517
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
   cancancan (3.6.1) sha256=975c1d5cbf58d5df48a9452a7f61ae3d254608cd87570402f5925a8864c56b62

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     bindex (0.8.1)
     binding_of_caller (2.0.0)
       debug_inspector (>= 1.2.0)
@@ -109,11 +109,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cgi (0.5.1)
+    cgi (0.5.2)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
     csv (3.3.5)
@@ -133,7 +133,7 @@ GEM
       rails-i18n
     diff-lcs (1.6.2)
     drb (2.2.3)
-    erb (6.0.2)
+    erb (6.0.6)
     erubi (1.13.1)
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
@@ -150,12 +150,12 @@ GEM
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
-    globalid (1.3.0)
+    globalid (1.4.0)
       activesupport (>= 6.1)
-    i18n (1.14.8)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    irb (1.17.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
@@ -181,23 +181,23 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.27.0)
     msgpack (1.8.0)
     nested_form (0.3.2)
-    net-imap (0.6.3)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -207,21 +207,21 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2-aarch64-linux-gnu)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-aarch64-linux-musl)
+    nokogiri (1.19.4-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-gnu)
+    nokogiri (1.19.4-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-musl)
+    nokogiri (1.19.4-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-darwin)
+    nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-musl)
+    nokogiri (1.19.4-x86_64-linux-musl)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (2.0.1)
@@ -235,7 +235,7 @@ GEM
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -251,9 +251,6 @@ GEM
       yard (~> 0.9.21)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
-    psych (5.3.1)
-      date
-      stringio
     public_suffix (7.0.5)
     puma (8.0.0)
       nio4r (~> 2.0)
@@ -284,8 +281,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (7.0.10)
       i18n (>= 0.7, < 2)
@@ -308,10 +305,15 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.4.1)
-    rdoc (7.2.0)
+    rake (13.4.2)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     regexp_parser (2.12.0)
     reline (0.6.3)
@@ -399,7 +401,6 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
-    stringio (3.2.0)
     thor (1.5.0)
     tilt (2.7.0)
     timeout (0.6.1)
@@ -421,14 +422,14 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.41)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   aarch64-linux
@@ -501,7 +502,7 @@ CHECKSUMS
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   better_errors (2.10.1) sha256=f798f1bac93f3e775925b7fcb24cffbcf0bb62ee2210f5350f161a6b75fc0a73
-  bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   binding_of_caller (2.0.0) sha256=e53eebf8428a85587aede7b43a83e7419eb85b8b690938a96aa330d03052d517
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
@@ -510,11 +511,11 @@ CHECKSUMS
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
   cancancan (3.6.1) sha256=975c1d5cbf58d5df48a9452a7f61ae3d254608cd87570402f5925a8864c56b62
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
-  cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
+  cgi (0.5.2) sha256=61ca30298171190fd4fa0d8018e57ada456eae9b7a2b78526debf7f0a0e6f8bb
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
-  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
-  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
   cssbundling-rails (1.4.3) sha256=53aecd5a7d24ac9c8fcd92975acd0e830fead4ee4583d3d3d49bb64651946e41
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
@@ -524,7 +525,7 @@ CHECKSUMS
   devise-i18n (1.16.0) sha256=a33306f90f317cfe92753a000064e3ba9dec3cab2d5d01ef40d30f4b6e24e753
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
+  erb (6.0.6) sha256=a9b24986700f5bf127c4f297c5403c3ca41b83b0a316c0cd09a096b56e644ae5
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   factory_bot (6.5.6) sha256=12beb373214dccc086a7a63763d6718c49769d5606f0501e0a4442676917e077
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
@@ -537,10 +538,10 @@ CHECKSUMS
   ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
-  globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
-  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
+  i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
-  irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
   json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
@@ -551,28 +552,28 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
-  mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
-  marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
+  loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
+  mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
+  marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   nested_form (0.3.2) sha256=b1c468d7eac781235861c2f74fc9f675df0c4d915d5724aaf7fd29f7891c0538
-  net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
+  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.2-aarch64-linux-gnu) sha256=c34d5c8208025587554608e98fd88ab125b29c80f9352b821964e9a5d5cfbd19
-  nokogiri (1.19.2-aarch64-linux-musl) sha256=7f6b4b0202d507326841a4f790294bf75098aef50c7173443812e3ac5cb06515
-  nokogiri (1.19.2-arm-linux-gnu) sha256=b7fa1139016f3dc850bda1260988f0d749934a939d04ef2da13bec060d7d5081
-  nokogiri (1.19.2-arm-linux-musl) sha256=61114d44f6742ff72194a1b3020967201e2eb982814778d130f6471c11f9828c
-  nokogiri (1.19.2-arm64-darwin) sha256=58d8ea2e31a967b843b70487a44c14c8ba1866daa1b9da9be9dbdf1b43dee205
-  nokogiri (1.19.2-x86_64-darwin) sha256=7d9af11fda72dfaa2961d8c4d5380ca0b51bc389dc5f8d4b859b9644f195e7a4
-  nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
-  nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
+  nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
+  nokogiri (1.19.4-aarch64-linux-musl) sha256=35c65b9ce72b3bb03207bdbe7067915019dc18c1b9b59139684bd6690fdd01af
+  nokogiri (1.19.4-arm-linux-gnu) sha256=a301313e38bb065d68239e79734bcd6f56fb6efaacebde29e9abf2a4735340ca
+  nokogiri (1.19.4-arm-linux-musl) sha256=588923c101bcfa78869734d247d25b598674323e7f22474fc468f6e5647311eb
+  nokogiri (1.19.4-arm64-darwin) sha256=a46db9853286e6597b36ebc6953817d15acf3a299583eb3f89fdc6f91dd63527
+  nokogiri (1.19.4-x86_64-darwin) sha256=7fd17057d3e1f00e9954a74b3cd76595d3d4a5ef233b7ed9599047c204f70551
+  nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
+  nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
   parallel (2.0.1) sha256=337782d3e39f4121e67563bf91dd8ece67f48923d90698614773a0ec9a5b2c7d
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
@@ -583,14 +584,13 @@ CHECKSUMS
   pg (1.6.3-x86_64-darwin) sha256=ee2e04a17c0627225054ffeb43e31a95be9d7e93abda2737ea3ce4a62f2729d6
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
-  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pry (0.16.0) sha256=d76c69065698ed1f85e717bd33d7942c38a50868f6b0673c636192b3d1b6054e
   pry-byebug (3.12.0) sha256=594e094ae8a8390a7ad4c7b36ae36e13304ed02664c67417d108dc5f7213d1b7
   pry-doc (1.7.0) sha256=6ada9fec062b54441c6444e44f94c345e5c8c0af499d654e40d5a581eb222d8e
   pry-rails (0.3.11) sha256=a69e28e24a34d75d1f60bcf241192a54253f8f7ef8a62cba1e75750a9653593d
-  psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   puma (8.0.0) sha256=1681050b8b60fab1d3033255ab58b6aec64cd063e43fc6f8204bcb8bf9364b88
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
@@ -600,13 +600,14 @@ CHECKSUMS
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (7.2.3.1) sha256=96c0a0160081ef3f1e407438880f6194c6ec94cdf40c8f83fc7bb22c279eba94
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
-  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
   rails-i18n (7.0.10) sha256=efae16e0ac28c0f42e98555c8db1327d69ab02058c8b535e0933cb106dd931ca
   rails_admin (3.3.0) sha256=666c40a0931ee4f6e29e6db1df69df72417218d553af25b2fb56cdc94e2cfbf9
   railties (7.2.3.1) sha256=aea3393ee10243ceedcbeccb45458a0d58b524b6d21bf32eff8b93853baae15a
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
-  rake (13.4.1) sha256=b4e81bd6a748308a6799619d824ec6a23cd1acd07d9ec41e5f2ebfb2294447c8
-  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rbs (4.0.3) sha256=5a7bf70e2628549d9a1f44eae447b2cfe55968a9c60cfff52693a4bdcc020e14
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   responders (3.2.0) sha256=89c2d6ac0ae16f6458a11524cae4a8efdceba1a3baea164d28ee9046bd3df55a
@@ -634,7 +635,6 @@ CHECKSUMS
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
   sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
-  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   tilt (2.7.0) sha256=0d5b9ba69f6a36490c64b0eee9f6e9aad517e20dcc848800a06eb116f08c6ab3
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
@@ -647,11 +647,11 @@ CHECKSUMS
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   web-console (4.2.1) sha256=e7bcf37a10ea2b4ec4281649d1cee461b32232d0a447e82c786e6841fd22fe20
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
-  websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
+  websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   yard (0.9.41) sha256=2fad2f362bceb63101f37aeb81d35cfc50b4ae1c11cf22f54b8d46626877a89f
-  zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
+  zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 
 BUNDLED WITH
   4.0.10

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -18,6 +18,21 @@ class ReviewsController < ApplicationController
     end
   end
 
+  def edit
+    @eaten_food = current_user.eaten_foods.find(params[:eaten_food_id])
+    @review = @eaten_food.review
+  end
+
+  def update
+    @eaten_food = current_user.eaten_foods.find(params[:eaten_food_id])
+    @review = @eaten_food.review
+    if @review.update(review_params)
+      redirect_to reviews_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   def destroy
     eaten_food = current_user.eaten_foods.find(params[:eaten_food_id])
     review = eaten_food.review

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,7 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import Raty from "./raty"
+import "./raty_display"
 
 // ratyアクションの定義
 window.raty = function(elem,opt){ 

--- a/app/javascript/raty_display.js
+++ b/app/javascript/raty_display.js
@@ -1,0 +1,19 @@
+document.addEventListener("turbo:load", () => {
+  const starOn  = "/assets/star-on.png";
+  const starOff = "/assets/star-off.png";
+  const starHalf = "/assets/star-half.png";
+
+  document.querySelectorAll(".raty").forEach((elem) => {
+    const score = Number(elem.dataset.score);
+
+    elem.innerHTML = "";
+
+    window.raty(elem, {
+      starOn: starOn,
+      starOff: starOff,
+      starHalf: starHalf,
+      score: score,
+      readOnly: true,
+    });
+  });
+});

--- a/app/views/eaten_foods/index.html.erb
+++ b/app/views/eaten_foods/index.html.erb
@@ -26,8 +26,7 @@
         <!-- レビューボタン -->
         <div class="w-1/5 text-center">
           <% if eaten.review.present? %>
-            <p class="text-gray-800 font-semibold">レビュー済み</p>
-            <!-- <%= link_to "レビューを編集", '#', class: "inline-flex items-center gap-2 border border-gray-400 text-gray-800 font-bold bg-white px-3 py-1.5 rounded-md hover:bg-gray-100 text-sm" %> -->
+            <%= link_to "レビューを編集", edit_eaten_food_review_path(eaten_food_id: eaten.id), class: "inline-flex items-center gap-2 border border-gray-400 text-gray-800 font-bold bg-white px-3 py-1.5 rounded-md hover:bg-gray-100 text-sm" %>
           <% else %>
             <%= link_to "レビューを書く", new_eaten_food_review_path(eaten_food_id: eaten.id), class: "inline-flex items-center gap-2 border border-gray-400 text-gray-800 font-bold bg-white px-3 py-1.5 rounded-md hover:bg-gray-100 text-sm" %>
           <% end %>

--- a/app/views/eaten_foods/index.html.erb
+++ b/app/views/eaten_foods/index.html.erb
@@ -13,7 +13,7 @@
           <% if eaten.review.present? %>
             <div class="flex items-center justify-center gap-1">
               <p class="text-gray-800 font-semibold">満足度：</p>
-              <div id="star_<%= eaten.review.id %>" class="raty inline-block" data-score="<%= eaten.review.satisfaction %>"></div>
+              <div class="raty inline-block" data-score="<%= eaten.review.satisfaction %>"></div>
             </div>
           <% else %>
             <p class="text-gray-800 font-semibold">未レビュー</p>
@@ -45,21 +45,3 @@
     </div>
   <% end %>
 </div>
-
-<script>
-document.addEventListener("turbo:load", () => {
-  document.querySelectorAll(".raty").forEach((elem) => {
-    const score = Number(elem.dataset.score);
-
-    elem.innerHTML = "";
-
-    window.raty(elem, {
-      starOn: "<%= asset_path('star-on.png') %>",
-      starOff: "<%= asset_path('star-off.png') %>",
-      starHalf: "<%= asset_path('star-half.png') %>",
-      score: score,
-      readOnly: true,
-    });
-  });
-});
-</script>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -67,21 +67,3 @@
       </div>
     <% end %>
   </div>
-
-<script>
-document.addEventListener("turbo:load", () => {
-  document.querySelectorAll(".raty").forEach((elem) => {
-    const score = Number(elem.dataset.score);
-
-    elem.innerHTML = "";
-
-    window.raty(elem, {
-      starOn: "<%= asset_path('star-on.png') %>",
-      starOff: "<%= asset_path('star-off.png') %>",
-      starHalf: "<%= asset_path('star-half.png') %>",
-      score: score,
-      readOnly: true,
-    });
-  });
-});
-</script>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,0 +1,41 @@
+<%= form_with model: @review, url: eaten_food_review_path(@eaten_food) do |f| %>
+      <div class="field mb-2">
+        <p><%= f.label :satisfaction, "満足度", class: "block text-sm font-medium text-gray-700" %></p>
+        <!-- ratyを描画 -->
+        <div id="star_new" class="raty"></div>
+        <!-- 実際に送信される値 -->
+        <%= f.hidden_field :satisfaction, id: "satisfaction_new" %>
+      </div>
+
+      <div class="field">
+        <p><%= f.label :comment, "コメント", class: "block text-sm font-medium text-gray-700" %></p>
+        <p><%= f.text_field :comment, class: "mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm" %></p>
+      </div>
+
+      <div class="actions mt-6">
+        <%= f.submit "投稿", class: "w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 transition" %>
+      </div>
+<% end %>
+
+<script>
+document.addEventListener("turbo:load", () => {
+  const elem = document.querySelector("#star_new");
+  if (!elem) return;
+
+  const hidden = document.querySelector("#satisfaction_new");
+
+  elem.removeAttribute("data-read-only");
+  elem.removeAttribute("style");
+  elem.innerHTML = "";
+
+  window.raty(elem, {
+    starOn: "<%= asset_path('star-on.png') %>",
+    starOff: "<%= asset_path('star-off.png') %>",
+    starHalf: "<%= asset_path('star-half.png') %>",
+    score: <%= @review.satisfaction || 0 %>,
+    click: function(score) {
+      hidden.value = score;
+    }
+  });
+});
+</script>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,0 +1,48 @@
+<div class="min-h-screen flex items-center justify-center">
+  <div class="w-full max-w-md bg-white shadow-md rounded-lg p-8">
+    <h2 class="text-2xl font-bold mb-6 text-gray-800">レビュー編集</h2>
+    <h2 class="text-xl font-bold mb-2 text-gray-700"><%= @eaten_food.food.name %></h2>
+    
+    <%= form_with model: @review, url: eaten_food_review_path(@eaten_food) do |f| %>
+      <div class="field mb-2">
+        <p><%= f.label :satisfaction, "満足度", class: "block text-sm font-medium text-gray-700" %></p>
+        <!-- ratyを描画 -->
+        <div id="star_new" class="raty"></div>
+        <!-- 実際に送信される値 -->
+        <%= f.hidden_field :satisfaction, id: "satisfaction_new" %>
+      </div>
+
+      <div class="field">
+        <p><%= f.label :comment, "コメント", class: "block text-sm font-medium text-gray-700" %></p>
+        <p><%= f.text_field :comment, class: "mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm" %></p>
+      </div>
+
+      <div class="actions mt-6">
+        <%= f.submit "投稿", class: "w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 transition" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<script>
+document.addEventListener("turbo:load", () => {
+  const elem = document.querySelector("#star_new");
+  if (!elem) return;
+
+  const hidden = document.querySelector("#satisfaction_new");
+
+  elem.removeAttribute("data-read-only");
+  elem.removeAttribute("style");
+  elem.innerHTML = "";
+
+  window.raty(elem, {
+    starOn: "<%= asset_path('star-on.png') %>",
+    starOff: "<%= asset_path('star-off.png') %>",
+    starHalf: "<%= asset_path('star-half.png') %>",
+    score: <%= @review.satisfaction || 0 %>,
+    click: function(score) {
+      hidden.value = score;
+    }
+  });
+});
+</script>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -2,47 +2,6 @@
   <div class="w-full max-w-md bg-white shadow-md rounded-lg p-8">
     <h2 class="text-2xl font-bold mb-6 text-gray-800">レビュー編集</h2>
     <h2 class="text-xl font-bold mb-2 text-gray-700"><%= @eaten_food.food.name %></h2>
-    
-    <%= form_with model: @review, url: eaten_food_review_path(@eaten_food) do |f| %>
-      <div class="field mb-2">
-        <p><%= f.label :satisfaction, "満足度", class: "block text-sm font-medium text-gray-700" %></p>
-        <!-- ratyを描画 -->
-        <div id="star_new" class="raty"></div>
-        <!-- 実際に送信される値 -->
-        <%= f.hidden_field :satisfaction, id: "satisfaction_new" %>
-      </div>
-
-      <div class="field">
-        <p><%= f.label :comment, "コメント", class: "block text-sm font-medium text-gray-700" %></p>
-        <p><%= f.text_field :comment, class: "mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm" %></p>
-      </div>
-
-      <div class="actions mt-6">
-        <%= f.submit "投稿", class: "w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 transition" %>
-      </div>
-    <% end %>
+    <%= render 'form', review: @review %>
   </div>
 </div>
-
-<script>
-document.addEventListener("turbo:load", () => {
-  const elem = document.querySelector("#star_new");
-  if (!elem) return;
-
-  const hidden = document.querySelector("#satisfaction_new");
-
-  elem.removeAttribute("data-read-only");
-  elem.removeAttribute("style");
-  elem.innerHTML = "";
-
-  window.raty(elem, {
-    starOn: "<%= asset_path('star-on.png') %>",
-    starOff: "<%= asset_path('star-off.png') %>",
-    starHalf: "<%= asset_path('star-half.png') %>",
-    score: <%= @review.satisfaction || 0 %>,
-    click: function(score) {
-      hidden.value = score;
-    }
-  });
-});
-</script>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -19,14 +19,11 @@
               <p class="text-gray-600 text-lg font-semibold">カテゴリー : <%= food.category.name %></p>
               <p class="text-gray-500 text-sm">食べた日：<%= eaten.ate_on %></p>
             </div>
-          <!-- 編集 + 削除ボタン -->
           <div class="flex flex-col gap-2 items-end">
             <!-- 編集ボタン -->
-            <%= link_to "レビューを編集", '#', class: "inline-flex items-center gap-2 border border-gray-400 text-gray-800 font-bold bg-white px-3 py-1.5 rounded-md hover:bg-gray-100 text-sm" %>
+            <%= link_to "レビューを編集", edit_eaten_food_review_path(eaten_food_id: eaten.id), class: "inline-flex items-center gap-2 border border-gray-400 text-gray-800 font-bold bg-white px-3 py-1.5 rounded-md hover:bg-gray-100 text-sm" %>
             <!-- 削除ボタン -->
-            <%= link_to "削除", eaten_food_review_path(eaten),
-                  data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
-                  class: "inline-flex items-center gap-2 bg-red-600 text-white font-bold px-3 py-1.5 rounded-md hover:bg-red-700 text-sm" %>
+            <%= link_to "削除", eaten_food_review_path(eaten), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" }, class: "inline-flex items-center gap-2 bg-red-600 text-white font-bold px-3 py-1.5 rounded-md hover:bg-red-700 text-sm" %>
           </div>
         </div>
         <div class="flex justify-between items-center">

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -2,47 +2,6 @@
   <div class="w-full max-w-md bg-white shadow-md rounded-lg p-8">
     <h2 class="text-2xl font-bold mb-6 text-gray-800">レビュー投稿</h2>
     <h2 class="text-xl font-bold mb-2 text-gray-700"><%= @eaten_food.food.name %></h2>
-    
-    <%= form_with model: @review, url: eaten_food_review_path(@eaten_food) do |f| %>
-      <div class="field mb-2">
-        <p><%= f.label :satisfaction, "満足度", class: "block text-sm font-medium text-gray-700" %></p>
-        <!-- ratyを描画 -->
-        <div id="star_new" class="raty"></div>
-        <!-- 実際に送信される値 -->
-        <%= f.hidden_field :satisfaction, id: "satisfaction_new" %>
-      </div>
-
-      <div class="field">
-        <p><%= f.label :comment, "コメント", class: "block text-sm font-medium text-gray-700" %></p>
-        <p><%= f.text_field :comment, class: "mt-1 w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm" %></p>
-      </div>
-
-      <div class="actions mt-6">
-        <%= f.submit "投稿", class: "w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 transition" %>
-      </div>
-    <% end %>
+    <%= render 'form', review: @review %>
   </div>
 </div>
-
-<script>
-document.addEventListener("turbo:load", () => {
-  const elem = document.querySelector("#star_new");
-  if (!elem) return;
-
-  const hidden = document.querySelector("#satisfaction_new");
-
-  elem.removeAttribute("data-read-only");
-  elem.removeAttribute("style");
-  elem.innerHTML = "";
-
-  window.raty(elem, {
-    starOn: "<%= asset_path('star-on.png') %>",
-    starOff: "<%= asset_path('star-off.png') %>",
-    starHalf: "<%= asset_path('star-half.png') %>",
-    score: <%= @review.satisfaction || 0 %>,
-    click: function(score) {
-      hidden.value = score;
-    }
-  });
-});
-</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
   end
   resources :wishlist_foods, only: %i[create destroy]
   resources :eaten_foods, only: %i[index new create destroy] do
-    resource :review, only: %i[new create destroy]
+    resource :review, only: %i[new create edit update destroy]
   end
   resources :reviews, only: %i[index]
 end


### PR DESCRIPTION
## 概要
レビュー編集機能を実装しました。

## 背景
レビュー編集機能 #78

## 変更内容
- `reviews`の`edit`、`update`アクションを実装
-  編集フォームで既存の満足度を初期表示
- 編集後のリダイレクト先を`reviews_path`に設定
- レビュー入力フォームの切り出し（`views/reviews/_form.html.erb`）
- 表示用`raty`を外部JS（`raty_display.js`）へ切り出し

## 確認方法
- `/eaten_foods/:id/review/edit`にアクセスし、既存レビューが正しく表示されること
- 星評価を変更して保存できること
- 保存後に`reviews_path`し、レビューが正しく更新されること
- 一覧ページで星評価が正しく表示されること（外部JSが動作していること）

## 影響範囲
- レビュー新規・編集フォーム
- レビュー一覧（星評価表示）
- `raty`の描画処理（表示用のみ外部JS化）

## 補足
入力用`raty`は`ERB`が必要なため切り出したフォーム（`views/reviews/_form.html.erb`）へ移動した。